### PR TITLE
[new] `AnyLinkPreview.builder` to use itemBuilder and build custom wi…

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,6 +22,7 @@ class _MyAppState extends State<MyApp> {
       "https://twitter.com/laravelphp/status/1222535498880692225";
   final String _url4 = "https://www.youtube.com/watch?v=W1pNjxmNHNQ";
   final String _url5 = "https://www.brainyquote.com/topics/motivational-quotes";
+  final String _url6 = "https://flutter.dev/";
 
   @override
   void initState() {
@@ -66,7 +67,7 @@ class _MyAppState extends State<MyApp> {
             children: [
               AnyLinkPreview(
                 link: _url1,
-                displayDirection: UIDirection.UIDirectionHorizontal,
+                displayDirection: UIDirection.uiDirectionHorizontal,
                 cache: Duration(hours: 1),
                 backgroundColor: Colors.grey[300],
                 errorWidget: Container(
@@ -78,7 +79,7 @@ class _MyAppState extends State<MyApp> {
               SizedBox(height: 25),
               AnyLinkPreview(
                 link: _url2,
-                displayDirection: UIDirection.UIDirectionHorizontal,
+                displayDirection: UIDirection.uiDirectionHorizontal,
                 showMultimedia: false,
                 bodyMaxLines: 5,
                 bodyTextOverflow: TextOverflow.ellipsis,
@@ -91,13 +92,65 @@ class _MyAppState extends State<MyApp> {
               ),
               SizedBox(height: 25),
               AnyLinkPreview(
-                displayDirection: UIDirection.UIDirectionHorizontal,
+                displayDirection: UIDirection.uiDirectionHorizontal,
                 link: _url3,
                 errorBody: 'Show my custom error body',
                 errorTitle: 'Next one is youtube link, error title',
               ),
               SizedBox(height: 25),
               AnyLinkPreview(link: _url4),
+              SizedBox(height: 25),
+              // Custom preview builder
+              AnyLinkPreview.builder(
+                link: _url6,
+                itemBuilder: (context, metadata, imageProvider) => Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (imageProvider != null)
+                      Container(
+                        constraints: BoxConstraints(
+                          maxHeight: MediaQuery.of(context).size.width * 0.5,
+                        ),
+                        decoration: BoxDecoration(
+                          image: DecorationImage(
+                            image: imageProvider,
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                      ),
+                    Container(
+                      width: double.infinity,
+                      color: Theme.of(context).primaryColor.withOpacity(0.6),
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 10, horizontal: 15),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (metadata.title != null)
+                            Text(
+                              metadata.title!,
+                              maxLines: 1,
+                              style:
+                                  const TextStyle(fontWeight: FontWeight.w500),
+                            ),
+                          const SizedBox(height: 5),
+                          if (metadata.desc != null)
+                            Text(
+                              metadata.desc!,
+                              maxLines: 1,
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          Text(
+                            metadata.url ?? _url6,
+                            maxLines: 1,
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ],
           ),
         ),

--- a/lib/src/widgets/link_view_horizontal.dart
+++ b/lib/src/widgets/link_view_horizontal.dart
@@ -1,11 +1,10 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
 
 class LinkViewHorizontal extends StatelessWidget {
   final String url;
   final String title;
   final String description;
-  final String imageUri;
+  final ImageProvider? imageProvider;
   final Function() onTap;
   final TextStyle? titleTextStyle;
   final TextStyle? bodyTextStyle;
@@ -20,7 +19,7 @@ class LinkViewHorizontal extends StatelessWidget {
     required this.url,
     required this.title,
     required this.description,
-    required this.imageUri,
+    required this.imageProvider,
     required this.onTap,
     this.titleTextStyle,
     this.bodyTextStyle,
@@ -71,13 +70,6 @@ class LinkViewHorizontal extends StatelessWidget {
               fontWeight: FontWeight.w400,
             );
 
-        ImageProvider? img_ = imageUri != '' ? NetworkImage(imageUri) : null;
-        if (imageUri.startsWith('data:image')) {
-          img_ = MemoryImage(
-            base64Decode(imageUri.substring(imageUri.indexOf('base64') + 7)),
-          );
-        }
-
         return InkWell(
           onTap: () => onTap(),
           child: Row(
@@ -85,13 +77,13 @@ class LinkViewHorizontal extends StatelessWidget {
               showMultiMedia!
                   ? Expanded(
                       flex: 2,
-                      child: img_ == null
+                      child: imageProvider == null
                           ? Container(color: bgColor ?? Colors.grey)
                           : Container(
                               margin: EdgeInsets.only(right: 5),
                               decoration: BoxDecoration(
                                 image: DecorationImage(
-                                  image: img_,
+                                  image: imageProvider!,
                                   fit: BoxFit.cover,
                                 ),
                                 borderRadius: radius == 0

--- a/lib/src/widgets/link_view_vertical.dart
+++ b/lib/src/widgets/link_view_vertical.dart
@@ -1,11 +1,10 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
 
 class LinkViewVertical extends StatelessWidget {
   final String url;
   final String title;
   final String description;
-  final String imageUri;
+  final ImageProvider? imageProvider;
   final Function() onTap;
   final TextStyle? titleTextStyle;
   final TextStyle? bodyTextStyle;
@@ -20,7 +19,7 @@ class LinkViewVertical extends StatelessWidget {
     required this.url,
     required this.title,
     required this.description,
-    required this.imageUri,
+    required this.imageProvider,
     required this.onTap,
     this.titleTextStyle,
     this.bodyTextStyle,
@@ -66,13 +65,6 @@ class LinkViewVertical extends StatelessWidget {
             fontWeight: FontWeight.w400,
           );
 
-      ImageProvider? img_ = imageUri != '' ? NetworkImage(imageUri) : null;
-      if (imageUri.startsWith('data:image')) {
-        img_ = MemoryImage(
-          base64Decode(imageUri.substring(imageUri.indexOf('base64') + 7)),
-        );
-      }
-
       return InkWell(
           onTap: () => onTap(),
           child: Column(
@@ -80,7 +72,7 @@ class LinkViewVertical extends StatelessWidget {
               showMultiMedia!
                   ? Expanded(
                       flex: 2,
-                      child: img_ == null
+                      child: imageProvider == null
                           ? Container(color: bgColor ?? Colors.grey)
                           : Container(
                               padding: EdgeInsets.only(bottom: 15),
@@ -92,7 +84,7 @@ class LinkViewVertical extends StatelessWidget {
                                         topRight: Radius.circular(12),
                                       ),
                                 image: DecorationImage(
-                                  image: img_,
+                                  image: imageProvider!,
                                   fit: BoxFit.fitWidth,
                                 ),
                               ),


### PR DESCRIPTION
This PR add a new `AnyLinkPreview.builder` constructor to provide an `itemBuilder` function (similar to ListView, GridView, ...). The purpose is to allow more customization on how to render the preview.

I updated the example to show how to use it. See below for [flutter.dev ](https://flutter.dev/) preview :

<img src="https://user-images.githubusercontent.com/22376981/175483876-930c54e7-30bf-4445-92c5-56e2a62794cc.PNG" data-canonical-src="https://user-images.githubusercontent.com/22376981/175483876-930c54e7-30bf-4445-92c5-56e2a62794cc.PNG" height="600" />
