### PR TITLE
Use client side render only as a backup if default result is empty

### DIFF
--- a/lib/src/parser/base.dart
+++ b/lib/src/parser/base.dart
@@ -14,6 +14,12 @@ mixin BaseMetaInfo {
   String? image;
   String? url;
 
+  /// Returns `true` if any parameter other than [url] is filled
+  bool get hasData =>
+      ((title?.isNotEmpty ?? false) && title != 'null') ||
+      ((desc?.isNotEmpty ?? false) && desc != 'null') ||
+      ((image?.isNotEmpty ?? false) && image != 'null');
+
   Metadata parse() {
     final m = Metadata();
     m.title = title;


### PR DESCRIPTION
Fixes #38.

Using `Googlebot` as user agent by default causes issue on some links.
For example, instagram redirects to login page after few anonymous requests which causes all the preview to be blocked.

This PR uses the `Googlebot` as user agent as a backup **ONLY** if the default HTTP request result with no user-agent specified is empty.

| Before PR |  After PR |
| -- | -- |
| ![IMG_1970](https://user-images.githubusercontent.com/22376981/203891459-217d6e9a-99ab-48e7-b083-8fcf36a3a687.PNG) | ![IMG_5EA17CC360F5-1](https://user-images.githubusercontent.com/22376981/203891805-fc978f3b-6e52-4e39-9a82-652847120a36.jpeg) |

