### PR TITLE
Don't convert null value into 'null' string.

### DIFF
--- a/lib/src/parser/util.dart
+++ b/lib/src/parser/util.dart
@@ -4,7 +4,7 @@ extension GetMethod on Map {
   String? get(dynamic key) {
     var value = this[key];
     if (value is List) return value.first;
-    return value.toString();
+    return value == null ? null : value.toString();
   }
 
   dynamic getDynamic(dynamic key) {


### PR DESCRIPTION
## Context
Some websites could have the tag that satisfies a certain parser, but still miss the actual value of it. These values are `null`. However, the value getter in `lib/src/parser/util.dart` ([link here](https://github.com/sur950/any_link_preview/blob/master/lib/src/parser/util.dart#L7)), does not check for this, but converts any value to `String`. Since `toString` has the ability to even convert `null` into `String` (`"null"`), the job is considered done, and no other parser will be able to attempt actually getting a proper value.

## Solution
Before converting value to `String`, check if value is null.

## Example
- [Try a very famous Swedish E-Commerce website Åhlens](https://www.ahlens.se/produkter/inredning/korg-hoogla-liten-358c72c3-382b-45da-ac11-a81a50212f3a).
- The `imageUrl` will be `"null"` (extracted from `og:image`), and will omit the `HtmlMetaParser` result, which will have found the correct URL.