### PR TITLE
refactor: add userAgent parameter to  AnyLinkPreview.getMetadata()

### DIFF
--- a/lib/src/helpers/link_analyzer.dart
+++ b/lib/src/helpers/link_analyzer.dart
@@ -72,15 +72,15 @@ class LinkAnalyzer {
     String url, {
     Duration? cache = const Duration(hours: 24),
     Map<String, String> headers = const {},
+    // 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)',
+    // 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    String? userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
   }) =>
       getInfo(
         url,
         cache: cache,
         headers: headers,
-        // 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)',
-        // 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
-        userAgent:
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+        userAgent: userAgent
       );
 
   /// Fetches a [url], validates it, and returns [Metadata].

--- a/lib/src/helpers/link_preview.dart
+++ b/lib/src/helpers/link_preview.dart
@@ -170,6 +170,7 @@ class AnyLinkPreview extends StatefulWidget {
     String? proxyUrl = '', // Pass for web
     Duration? cache = const Duration(days: 1),
     Map<String, String>? headers,
+    String? userAgent
   }) async {
     var linkValid = isValidLink(link);
     var proxyValid = true;
@@ -182,6 +183,7 @@ class AnyLinkPreview extends StatefulWidget {
         linkToFetch,
         cache: cache,
         headers: headers ?? {},
+        userAgent: userAgent
       );
     } else if (!linkValid) {
       throw Exception('Invalid link');
@@ -195,12 +197,14 @@ class AnyLinkPreview extends StatefulWidget {
     String link, {
     Duration? cache = const Duration(days: 1),
     Map<String, String>? headers,
+    String? userAgent
   }) async {
     try {
       var info = await LinkAnalyzer.getInfo(
         link,
         cache: cache,
         headers: headers ?? {},
+        userAgent: userAgent
       );
       if (info == null || info.hasData == false) {
         // if info is null or data is empty try to read url metadata from client side
@@ -208,6 +212,7 @@ class AnyLinkPreview extends StatefulWidget {
           link,
           cache: cache,
           headers: headers ?? {},
+          userAgent: userAgent
         );
       }
       return info;


### PR DESCRIPTION
Enable custom userAgent values to fix network issues - most of page can be parsed with default setting, but at least two polish ecommerces have issues:
* https://www.euro.com.pl/ladowarki-akumulatory-przenosne/baseus-ppdml-k01-powerbank-bipow-30000mah-usb-c-15w-czarny.bhtml - throws SocketException
* https://www.mediaexpert.pl/gaming/pokoj-gracza/fotele-gamingowe/fotel-gamingowy-mad-dog-gch701r-czerwony - reponse with 403

I test my change on my project and running 
```
    final Metadata? _metadata = await AnyLinkPreview.getMetadata(
      link: url,
      cache: null,
      userAgent: 'WhatsApp/2.21.12.21 A'
    );
```
works as expected - both sites respones with metadata