### PR TITLE
Add Function to Retrieve YouTube Video Data using YouTube's oEmbed API

### DIFF
--- a/lib/src/helpers/link_analyzer.dart
+++ b/lib/src/helpers/link_analyzer.dart
@@ -4,6 +4,7 @@ import 'dart:async' as async;
 import 'dart:convert';
 
 import 'package:any_link_preview/any_link_preview.dart';
+import 'package:any_link_preview/src/parser/youtube_parser.dart';
 import 'package:any_link_preview/src/utilities/http_redirect_check.dart';
 import 'package:flutter/foundation.dart';
 import 'package:html/dom.dart' show Document;
@@ -110,11 +111,18 @@ class LinkAnalyzer {
 
     try {
       // Make our network call
-      final response = await fetchWithRedirects(
-        url,
-        headers: headers,
-        userAgent: userAgent,
-      );
+      final videoId = getYouTubeVideoId(url);
+      final response = videoId == null
+          ? await fetchWithRedirects(
+              url,
+              headers: headers,
+              userAgent: userAgent,
+            )
+          : await getYoutubeData(
+              videoId,
+              headers: headers,
+              userAgent: userAgent,
+            );
       final headerContentType = response.headers['content-type'];
 
       if (headerContentType != null && headerContentType.startsWith('image/')) {
@@ -181,6 +189,7 @@ class LinkAnalyzer {
     final parsers = [
       _openGraph(document),
       _twitterCard(document),
+      _youtubeCard(document),
       _jsonLdSchema(document),
       _htmlMeta(document),
       _otherParser(document),
@@ -227,6 +236,14 @@ class LinkAnalyzer {
   static Metadata? _jsonLdSchema(Document? document) {
     try {
       return JsonLdParser(document).parse();
+    } catch (e) {
+      return null;
+    }
+  }
+
+  static Metadata? _youtubeCard(Document? document) {
+    try {
+      return YoutubeParser(document).parse();
     } catch (e) {
       return null;
     }

--- a/lib/src/parser/youtube_parser.dart
+++ b/lib/src/parser/youtube_parser.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'package:html/dom.dart';
+import 'base.dart';
+import 'util.dart';
+
+class YoutubeParser with BaseMetaInfo {
+  /// The [document] to be parse
+  Document? document;
+  dynamic _jsonData;
+
+  YoutubeParser(this.document) {
+    _jsonData = _parseToJson(document);
+  }
+
+  dynamic _parseToJson(Document? document) {
+    final data = document?.outerHtml
+        .replaceAll('<html><head></head><body>', '')
+        .replaceAll('</body></html>', '');
+    if (data == null) return null;
+    /* For multiline json file */
+    // Replacing all new line characters with empty space
+    // before performing json decode on data
+    var d = jsonDecode(data.replaceAll('\n', ' '));
+    return d;
+  }
+
+  /// Get the [Metadata.title] from the [<title>] tag
+  @override
+  String? get title {
+    final data = _jsonData;
+    if (data is List) {
+      return data.first['title'];
+    } else if (data is Map) {
+      return data.get('title');
+    }
+    return null;
+  }
+
+  /// Get the [Metadata.image] from the first <img> tag in the body
+  @override
+  String? get image {
+    final data = _jsonData;
+    if (data is List && data.isNotEmpty) {
+      return _imgResultToStr(data.first['thumbnail_url']);
+    } else if (data is Map) {
+      return _imgResultToStr(data.getDynamic('thumbnail_url'));
+    }
+    return null;
+  }
+
+  @override
+  String? get siteName {
+    final data = _jsonData;
+    if (data is List) {
+      return data.first['provider_name'];
+    } else if (data is Map) {
+      return data.get('provider_name');
+    }
+    return null;
+  }
+
+  @override
+  String? get url {
+    final data = _jsonData;
+    if (data is List) {
+      return data.first['provider_url'];
+    } else if (data is Map) {
+      return data.get('provider_url');
+    }
+    return null;
+  }
+
+  String? _imgResultToStr(dynamic result) {
+    if (result is List && result.isNotEmpty) result = result.first;
+    if (result is String) return result;
+    return null;
+  }
+
+  @override
+  String toString() => parse().toString();
+}

--- a/lib/src/utilities/http_redirect_check.dart
+++ b/lib/src/utilities/http_redirect_check.dart
@@ -38,3 +38,32 @@ Future<http.Response> fetchWithRedirects(
 bool _isRedirect(http.Response response) {
   return [301, 302, 303, 307, 308].contains(response.statusCode);
 }
+
+Future<http.Response> getYoutubeData(String videoId,
+    {Map<String, String>? headers, String? userAgent}) async {
+  String userAgentFallback =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3';
+  Map<String, String>? allHeaders = {
+    ...?headers,
+    'User-Agent': userAgent ?? userAgentFallback
+  };
+  var response = await http.get(
+      Uri.parse(
+          'https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=$videoId&format=json'),
+      headers: allHeaders);
+  return response;
+}
+
+String? getYouTubeVideoId(String url) {
+  // Regular expression pattern to detect YouTube URLs with or without a proxy prefix
+  final RegExp regExp = RegExp(
+      r'(?:https?:\/\/)?(?:[^\/]+\.)?(?:youtube\.com\/(?:watch\?v=|embed\/|v\/|v\/|.+\?v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})');
+
+  // Apply the regex to the URL
+  final match = regExp.firstMatch(url);
+
+  print(match?.group(1));
+
+  // If a match is found, return the first capture group, which is the video ID
+  return match?.group(1);
+}


### PR DESCRIPTION
This pull request enhances the `LinkAnalyzer` class to support YouTube link previews by integrating a new YouTube parser. The most important changes include adding the YouTube parser, modifying the existing link fetching logic to handle YouTube URLs, and updating the metadata extraction methods.

Why new method needed?:
* Although adding a proxy URL worked for other third-party URLs, it caused issues with YouTube. 1. Google uses region-specific cookies, which led to incorrect titles and images being returned. 2. Directly using a YouTube video URL that ends with `watch?v=VIDEO_ID` retrieves YouTube's general metadata rather than the specific metadata for the video.
* This new approach addresses that issue and ensures more reliable YouTube data retrieval. However, note that with this method, the video’s description will not be included due to limitations of `YouTube's oEmbed API`. 

Enhancements to YouTube link previews:

* [`lib/src/helpers/link_analyzer.dart`](diffhunk://#diff-41edd20cc1fbb639271e92a1cdbe6bc1538aab7f8d528d742b7f07b80da711e3R7): Added `youtube_parser.dart` import and updated the `LinkAnalyzer` class to handle YouTube URLs by extracting video IDs and fetching YouTube data.

New YouTube parser:

* [`lib/src/parser/youtube_parser.dart`](diffhunk://#diff-40d0e26926e8c851dac77a9cca1f489dff23b21648feaafa6796e8701564998cR1-R70): Implemented the `YoutubeParser` class to parse YouTube metadata, including title, image, url and site name.

Utility functions for YouTube data:

* [`lib/src/utilities/http_redirect_check.dart`](diffhunk://#diff-db363c1bf4e21542abffb6e060494c3406de0356e776fca049d9f6ad03ed0811R41-R69): Added `getYoutubeData` and `getYouTubeVideoId` functions to fetch YouTube metadata and extract video IDs from URLs.

Note: 
* Video description will not be fetched due to no description field in `YouTube's oEmbed API`
