### PR TITLE
Fix titleStyle comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ A Flutter package for beautifully displaying web URL previews with full customiz
   /// and always make a request for latest metadata.
   final Duration cache;
 
-  /// Customize body [TextStyle].
+  /// Customize title [TextStyle].
   final TextStyle? titleStyle;
 
   /// Customize body [TextStyle].

--- a/lib/src/helpers/link_preview.dart
+++ b/lib/src/helpers/link_preview.dart
@@ -66,7 +66,7 @@ class AnyLinkPreview extends StatefulWidget {
   /// and always make a request for latest metadata.
   final Duration cache;
 
-  /// Customize body [TextStyle].
+  /// Customize title [TextStyle].
   final TextStyle? titleStyle;
 
   /// Customize body [TextStyle].


### PR DESCRIPTION
## Summary
- correct comment for `titleStyle`
- mirror fix in README

## Testing
- `dart format --set-exit-if-changed lib/src/helpers/link_preview.dart README.md` *(fails: command not found)*
- `flutter format lib/src/helpers/link_preview.dart README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528ff023d0832ea668d9d151988a52