### PR TITLE
Fix fallback metadata handling

### DIFF
--- a/lib/src/helpers/cache_manager.dart
+++ b/lib/src/helpers/cache_manager.dart
@@ -18,9 +18,9 @@ class CacheManager {
     return jsonMapCache;
   }
 
-  static Future deleteKey(String key, [dynamic takeAction]) async {
+  static Future deleteKey(String key, [VoidCallback? takeAction]) async {
     final sharedPreferences = await SharedPreferences.getInstance();
-    await sharedPreferences.remove(key).whenComplete(() => takeAction);
+    await sharedPreferences.remove(key).whenComplete(() => takeAction?.call());
   }
 
   static Future setJson({

--- a/lib/src/helpers/link_analyzer.dart
+++ b/lib/src/helpers/link_analyzer.dart
@@ -100,14 +100,15 @@ class LinkAnalyzer {
     }
     if (info != null) return info;
 
+    // Initialize with fallback values in case the network call fails
+    info = Metadata()
+      ..title = getDomain(url)
+      ..desc = url
+      ..siteName = getDomain(url)
+      ..url = url;
+
     if (!isURL(url)) return null;
 
-    // Default values; Domain name as the [title],
-    // URL as the [description]
-    info?.title = getDomain(url);
-    info?.desc = url;
-    info?.siteName = getDomain(url);
-    info?.url = url;
 
     try {
       // Make our network call
@@ -149,7 +150,7 @@ class LinkAnalyzer {
     } catch (error) {
       debugPrint('AnyLinkPreview - Error in $url response ($error)');
       // Any sort of exceptions due to wrong URL's, host lookup failure etc.
-      return null;
+      return info;
     }
   }
 


### PR DESCRIPTION
## Summary
- initialize fallback Metadata before network request
- ensure the cache deletion callback executes if provided
- return fallback metadata when network calls fail

## Testing
- `dart format -o none lib/src/helpers/link_analyzer.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528ef61e4c832e90d19a44e4ccb45c