### PR TITLE
Fix callback invocation in cache manager

### DIFF
--- a/lib/src/helpers/cache_manager.dart
+++ b/lib/src/helpers/cache_manager.dart
@@ -20,7 +20,9 @@ class CacheManager {
 
   static Future deleteKey(String key, [VoidCallback? takeAction]) async {
     final sharedPreferences = await SharedPreferences.getInstance();
-    await sharedPreferences.remove(key).whenComplete(() => takeAction?.call());
+    await sharedPreferences
+        .remove(key)
+        .whenComplete(() => (takeAction as void Function()?)?.call());
   }
 
   static Future setJson({


### PR DESCRIPTION
## Summary
- call the optional callback using a cast in `deleteKey`

## Testing
- `dart test` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685296aaea74832e9ec7b10f332a42c4