### PR TITLE
Remove print from YouTube ID function

### DIFF
--- a/lib/src/utilities/http_redirect_check.dart
+++ b/lib/src/utilities/http_redirect_check.dart
@@ -64,8 +64,6 @@ String? getYouTubeVideoId(String url) {
   // Apply the regex to the URL
   final match = regExp.firstMatch(url);
 
-  print(match?.group(1));
-
   // If a match is found, return the first capture group, which is the video ID
   return match?.group(1);
 }


### PR DESCRIPTION
## Summary
- remove leftover debug print from `getYouTubeVideoId`

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685297bf3d84832e87ac07d2497c65a3