### PR TITLE
Fix URL validation logic

### DIFF
--- a/lib/src/utilities/image_provider.dart
+++ b/lib/src/utilities/image_provider.dart
@@ -157,5 +157,5 @@ ImageProvider? buildNetworkImage(String url, String? errorImageUrl) {
 /// Checks if a URL is valid.
 bool isValidUrl(String url) {
   final uri = Uri.tryParse(url);
-  return uri != null && uri.hasAbsolutePath;
+  return uri != null && uri.isAbsolute;
 }


### PR DESCRIPTION
## Summary
- fix URL validation for image provider

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685297bc1eb8832e8f0d856ae0c34311