### PR TITLE
Fix cache manager types

### DIFF
--- a/lib/src/helpers/cache_manager.dart
+++ b/lib/src/helpers/cache_manager.dart
@@ -3,17 +3,17 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class CacheManager {
-  static Future getJson({required String key}) async {
-    dynamic cache;
+  static Future<Map<String, dynamic>?> getJson({required String key}) async {
+    String? cache;
     try {
       final sharedPreferences = await SharedPreferences.getInstance();
       cache = sharedPreferences.getString(key);
     } catch (e) {
       debugPrint('Cache URL had a change => $e');
     }
-    dynamic jsonMapCache;
+    Map<String, dynamic>? jsonMapCache;
     if (cache != null) {
-      jsonMapCache = jsonDecode(cache) as Map<dynamic, dynamic>;
+      jsonMapCache = jsonDecode(cache) as Map<String, dynamic>;
     }
     return jsonMapCache;
   }
@@ -25,12 +25,11 @@ class CacheManager {
         .whenComplete(() => (takeAction as void Function()?)?.call());
   }
 
-  static Future setJson({
+  static Future<void> setJson({
     required String key,
-    required Map<dynamic, dynamic> value,
+    required Map<String, dynamic> value,
   }) async {
     final sharedPreferences = await SharedPreferences.getInstance();
-    var jsonMap = value;
-    await sharedPreferences.setString(key, jsonEncode(jsonMap));
+    await sharedPreferences.setString(key, jsonEncode(value));
   }
 }

--- a/lib/src/helpers/link_analyzer.dart
+++ b/lib/src/helpers/link_analyzer.dart
@@ -41,7 +41,8 @@ class LinkAnalyzer {
     Metadata? info_;
 
     try {
-      final infoJson = await CacheManager.getJson(key: url);
+      final Map<String, dynamic>? infoJson =
+          await CacheManager.getJson(key: url);
       if (infoJson != null) {
         info_ = Metadata.fromJson(infoJson);
         var isEmpty_ = info_.title == null || info_.title == 'null';


### PR DESCRIPTION
## Summary
- return typed map from `CacheManager.getJson`
- accept typed map in `CacheManager.setJson`
- update `LinkAnalyzer.getInfoFromCache` accordingly

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685297c02a34832e96a6be0a268d0167