### PR TITLE
Fix tests to use package:test

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  test: ^1.25.1
   flutter_lints: ^5.0.0
 
 # The following section is specific to Flutter.

--- a/test/any_link_preview_test.dart
+++ b/test/any_link_preview_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 import 'package:any_link_preview/any_link_preview.dart';
 


### PR DESCRIPTION
## Summary
- run Dart unit tests with the `test` package instead of `flutter_test`
- declare `test` as a dev dependency

## Testing
- `dart test` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852982f13b8832eb819f633699817fa